### PR TITLE
Customize timeouts

### DIFF
--- a/lib/send_sonar/client.rb
+++ b/lib/send_sonar/client.rb
@@ -1,8 +1,11 @@
 module SendSonar
   module Client
+    @@open_timeout = 2
+    @@timeout = 4
+
     def self.post(url, payload, headers={}, &block)
       RestClient::Request.execute(:method => :post, :url => url, :payload => payload, :headers => headers,
-        :open_timeout => 2, :timeout => 4, &block)
+        :open_timeout => @@open_timeout, :timeout => @@timeout, &block)
 
     rescue Errno::ECONNREFUSED => e
       raise ConnectionRefused.new(e)

--- a/lib/send_sonar/client.rb
+++ b/lib/send_sonar/client.rb
@@ -3,6 +3,22 @@ module SendSonar
     @@open_timeout = 2
     @@timeout = 4
 
+    def self.open_timeout
+      @@open_timeout
+    end
+
+    def self.open_timeout=(timeout)
+      @@open_timeout = timeout
+    end
+
+    def self.timeout
+      @@timeout
+    end
+
+    def self.timeout=(timeout)
+      @@timeout = timeout
+    end
+
     def self.post(url, payload, headers={}, &block)
       RestClient::Request.execute(:method => :post, :url => url, :payload => payload, :headers => headers,
         :open_timeout => @@open_timeout, :timeout => @@timeout, &block)

--- a/lib/send_sonar/configuration.rb
+++ b/lib/send_sonar/configuration.rb
@@ -23,6 +23,22 @@ module SendSonar
       end
     end
 
+    def open_timeout
+      Client.open_timeout
+    end
+
+    def open_timeout=(timeout)
+      Client.open_timeout = timeout
+    end
+
+    def timeout
+      Client.timeout
+    end
+
+    def timeout=(timeout)
+      Client.timeout = timeout
+    end
+
     private
 
     def env_choices


### PR DESCRIPTION
We currently see a large number of timeouts with SimpleDesk requests. I feel that the hardcoded 2 and 4 second timeouts are too aggressive for what the capacity of the service. This will allow users customize timeouts to their liking with code such as:

``` Ruby
SendSonar.configure do |config|
  config.open_timeout = 10
  config.timeout = 20
end
```
