### PR TITLE
Update RestClient to ~> 2.0.1

### DIFF
--- a/lib/send_sonar/exceptions.rb
+++ b/lib/send_sonar/exceptions.rb
@@ -24,7 +24,7 @@ module SendSonar
     end
 
     def inspect
-      @original_exception.inspect
+      "#{@original_exception.to_s}: #{@original_exception.http_body}"
     end
 
     def to_s

--- a/send_sonar.gemspec
+++ b/send_sonar.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr", "~> 2.6"
   spec.add_development_dependency "webmock", "~> 1.1"
   spec.add_development_dependency "json"
+  spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "rest-client", '~> 1.6'
+  spec.add_runtime_dependency "rest-client", '~> 2.0.1'
 end


### PR DESCRIPTION
Bump the RestClient version from ~> 1.6 to ~> 2.0.1

Our app currently uses RestClient 2.0.1, so Bundler wasn't able to install the Sonar gem. We obviously would prefer to use the official Ruby gem versus writing our own client.